### PR TITLE
nmapxml: don't use unnecessary temporary files

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -346,9 +346,6 @@ function searchsploitout()
 ## Read XML file
 function nmapxml()
 {
-  ## Remove any old traces
-  rm -f /tmp/searchsploit.{tmp,out}
-
   ## Feedback to the end user
   echo -e "[i] Reading: '${FILE}'\n"
 
@@ -368,29 +365,24 @@ function nmapxml()
           ## If we have already looped around and got something, save it before moving onto the current value
           if [[ "${software}" ]]; then
             #searchsploitout
-            echo "${software}" >> /tmp/searchsploit.out
+            echo "${software}"
           fi
           ## Something is better than nothing. Will just go on the default service that matches the port.   e.g. domain
           software="${input}"
           ## Might not get any more than this, if -sV failed
-          echo "${software}" > /tmp/searchsploit.tmp
           ;;
         "[PRODUCT]")
           ## We have a name, but no version (yet?)   e.g. dnsmasq
           software="${input}"
-          echo "${software}" > /tmp/searchsploit.tmp
           ;;
         "[VERSION]")
           software="${software} ${input}"
           ## Name & version. There isn't any more information to get, game over.   e.g. dnsmasq 2.72
-          echo "${software}" >> /tmp/searchsploit.out
-          echo "" > /tmp/searchsploit.tmp
+          echo "${software}"
+          software=
           ;;
       esac
-  done
-
-  ## Read in from file (so there are no duplicates - ...but unable to print out IPs)
-  cat /tmp/searchsploit.out /tmp/searchsploit.tmp 2>/dev/null | tr '[:upper:]' '[:lower:]' | awk '!x[$0]++' | while read software; do
+  done | tr '[:upper:]' '[:lower:]' | awk '!x[$0]++' | while read software; do
     searchsploitout
   done
 }


### PR DESCRIPTION
Instead of saving data to insecure temporary files created without mktemp, simply echo them directly to the next stage of a pipeline.

Also reset the $software at the beginning of each round, to prevent processing and then having to deduplicate many things, twice.

...

I'm not sure what the full implications are of allowing anyone on the system to overwrite the data to be searched, other than of course corrupting the search. But there's an uncomfortable amount of eval going on in this script, so I don't want to risk it...

Either way though, it's simply completely unnecessary in basically any case ever, to use temporary files as holding cells for data. Using a pipeline like I did here, or simply storing the data in bash arrays, is usually going to be both safer and more efficient.