### PR TITLE
print() instead of print for python3 for 42627.py

### DIFF
--- a/exploits/linux/remote/42627.py
+++ b/exploits/linux/remote/42627.py
@@ -84,7 +84,7 @@ def exploration(command):
 			'Content-Type': 'application/xml'}
 
 	request = requests.post(url, data=exploit, headers=headers)
-	print request.text
+	print(request.text)
 
 if len(sys.argv) < 3:
 	print ('CVE: 2017-9805 - Apache Struts2 Rest Plugin Xstream RCE')


### PR DESCRIPTION
`print()` instead of `print` for python3 for `exploits/linux/remote/42627.py`