### PR TITLE
Bug fix for searchsploit unable to DB information for products

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -374,6 +374,7 @@ function nmapxml()
         "[PRODUCT]")
           ## We have a name, but no version (yet?)   e.g. dnsmasq
           software="${input}"
+          echo "${software}"
           ;;
         "[VERSION]")
           software="${software} ${input}"


### PR DESCRIPTION
Issue: https://github.com/offensive-security/exploitdb/issues/158

While debugging nmapxml, I found that only those softwares are passed to searchsploitout which are echoed to stdout.
In this case, nostromo was classified as a product but there was no echo command for it in the case block "[PRODUCT]".

The fix adds a single line of echo to handle this scenario