### PR TITLE
Issue in JSON result output due to improper sanitization

### DIFF
--- a/searchsploit
+++ b/searchsploit
@@ -499,8 +499,7 @@ function findresults()
 
   ## Strip un-wanted values from titles
   #SEARCH="${SEARCH} | sed 's/\"//g"
-  SEARCH="${SEARCH} | sed 's/,\"/,/; s/\"$//;'"
-
+  SEARCH="${SEARCH} | sed 's/\"//g; s/$//g;'"
 
   ## Remove any terms not wanted from the search
   [[ "${EXCLUDE}" ]] \


### PR DESCRIPTION
The sed expressions did not replace the quotes in the parsed fields and resulted in double quotes being push to the output variable affecting the results printed to stdout. I have added an expression which will replace all quotes in a given field.

https://github.com/offensive-security/exploitdb/issues/167