### PR TITLE
Comments were not properly commented. Resolved.

### DIFF
--- a/exploits/php/webapps/41564.php
+++ b/exploits/php/webapps/41564.php
@@ -13,7 +13,7 @@
 #
 # Three stages:
 # 1. Use the SQL Injection to get the contents of the cache for current
-endpoint
+# endpoint
 #    along with admin credentials and hash
 # 2. Alter the cache to allow us to write a file and do so
 # 3. Restore the cache
@@ -68,7 +68,7 @@ class DatabaseCondition
 class SelectQueryExtender {
     # Contains a DatabaseCondition object instead of a SelectQueryInterface
     # so that $query->compile() exists and (string) $query is controlled by
-us.
+    # us.
     protected $query = null;
 
     protected $uniqueIdentifier = QID;


### PR DESCRIPTION
A couple instances of comments were found without '#' symbol. This
resulted in syntax errors when exploit was run. This patch should fix
the issue.

This patch only makes changes to comments. The functionality of the
exploit should remain unchanged.