### PR TITLE
adding comma between References.arrays

### DIFF
--- a/exploits/php/remote/46698.rb
+++ b/exploits/php/remote/46698.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References' =>
         [
-          ['URL', 'http://pentest.com.tr/exploits/CuteNews-2-1-2-Remote-Code-Execution-Metasploit.html']
+          ['URL', 'http://pentest.com.tr/exploits/CuteNews-2-1-2-Remote-Code-Execution-Metasploit.html'],
           ['URL', 'http://cutephp.com'] # Official Website
         ],
       'Platform' => 'php',


### PR DESCRIPTION
The module  CuteNews 2.1.2 - 'avatar' Remote C | php/remote/46698.rb
can not be louded properly due missing comma between References.Arrays

 


