### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,7 @@ If you have [homebrew](http://brew.sh/) ([package](https://github.com/Homebrew/h
 user@MacBook:~$ brew update && brew install exploitdb
 ```
 
-**Snapstore**
-
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/searchsploit)
+**Snap**
 
 If you're using any Linux distribution with [snapd](https://snapcraft.io/docs/installing-snapd) installed, then running the following will get you set up:
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ If you have [homebrew](http://brew.sh/) ([package](https://github.com/Homebrew/h
 user@MacBook:~$ brew update && brew install exploitdb
 ```
 
+**Snapstore**
+
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/searchsploit)
+
+If you're using any Linux distribution with [snapd](https://snapcraft.io/docs/installing-snapd) installed, then running the following will get you set up:
+
+```
+user@Linux:~$ sudo snap install searchsploit
+```
+
 - - -
 
 ## Credit


### PR DESCRIPTION
Now, `searchsploit` is available as a snap package in stable channel.